### PR TITLE
페이징 번호 클릭 되지 않은 문제 수정

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -615,6 +615,9 @@ a.tag:hover {
 
 #pagination > li > a {
     color: #1e1e1e;
+    width: 100%;
+    height: 100%;
+    display:block;
 }
 
 #page-prev {
@@ -1626,4 +1629,3 @@ body.page-template {
         background-image: url(../images/mo/default_pic_l@3x.png);
     }
 }
-


### PR DESCRIPTION
pagination 에서 페이징 번호, next, prev 버튼 클릭이 잘 되지 않는 문제 수정
- li 안에 a 링크의 영역이 지정이 되어 있지 않아 block 스타일 적용
- next, prev 버튼 안의 span 이  position 값이 absolute로 링크 안에 범위에 포함이 되지 않아
클릭 자체가 되지 않은 문제 함께 해결