### PR TITLE
facebook 페이지가 존재하지 않은 문제 수정

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,7 @@ google_analytics:
   ua: 'UA-72007721-1'
 facebook:
   app_id: '1204347326263800'
-  username: kakaocorp
+  username: nkakao
 twitter:
   username: kakaodev
 google_plus:


### PR DESCRIPTION
현재 footer의 facebook 링크에 대한 페이지가 존재하지 않습니다.
http://facebook.com/kakaocorp

facebook 페이지의 username을 아래와 같이 수정했습니다.
http://facebook.com/nkakao