### PR TITLE
footer의 Jobs url 변경

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -29,7 +29,7 @@
     </ul>
     <ul id="footer-menu">
         <li><a href="//www.kakaocorp.com">Kakao</a></li>
-        <li><a href="//www.kakaocorp.com/recruit/currentOpportunities">Jobs</a></li>
+        <li><a href="//careers.kakao.com/jobs">Jobs</a></li>
         <li><a href="//privacy.kakaocorp.com">Privacy</a></li>
     </ul>
     <p id="copyright">


### PR DESCRIPTION
안녕하세요.
기술블로그 하단 왼편의 "Jobs" 의 링크를 클릭하니 "페이지를 찾을수 없습니다." 메시지가 나와서,
현재의 채용사이트로 링크를 변경하여 PR드립니다.

감사합니다.